### PR TITLE
Remove Sys.exit() stopping script

### DIFF
--- a/scripts/python/scripts/create_ppmi_database.py
+++ b/scripts/python/scripts/create_ppmi_database.py
@@ -12,8 +12,6 @@ sys.path = [''] + sys.path # Add current directory to the path
 import ppmilib
 import ppmilib.utils
 
-sys.exit()
-
 class PPMIFile:
     """ 
         Read in a csv ppmi file and extract/set information about it. 


### PR DESCRIPTION
There was a sys.exit() statement remaining from the previous fix. It would prevent the whole create script from running and would exit prematurely. 